### PR TITLE
Use repo-file-sync-action to standardise `pre-commit-config.yaml`

### DIFF
--- a/.github/template-sync.yml
+++ b/.github/template-sync.yml
@@ -1,6 +1,6 @@
 # Note: SciTools/cartopy is managed by a separate development team so is not
 #  included in the templating.
 
-trexfeathers/iris@demo_20230817_main:
+SciTools/iris@demo_20230817_main:
   - source: templates/.pre-commit-config.yaml
     dest: .pre-commit-config.yaml

--- a/.github/template-sync.yml
+++ b/.github/template-sync.yml
@@ -2,5 +2,5 @@
 #  included in the templating.
 
 SciTools/iris@demo_20230817_main:
-  - source: templates/.pre-commit-config.yaml
-    dest: .pre-commit-config.yaml
+  - source: templates/.pre-commit-config.yamll
+    dest: .pre-commit-config.yamll

--- a/.github/template-sync.yml
+++ b/.github/template-sync.yml
@@ -1,0 +1,27 @@
+# Note: SciTools/cartopy is managed by a separate development team so is not
+#  included in the templating.
+
+SciTools/cf-units:
+  - source: templates/.pre-commit-config.yaml
+    dest: .pre-commit-config.yaml
+SciTools/iris:
+  - source: templates/.pre-commit-config.yaml
+    dest: .pre-commit-config.yaml
+SciTools/mo_pack:
+  - source: templates/.pre-commit-config.yaml
+    dest: .pre-commit-config.yaml
+SciTools/nc-time-axis:
+  - source: templates/.pre-commit-config.yaml
+    dest: .pre-commit-config.yaml
+SciTools/python-stratify:
+  - source: templates/.pre-commit-config.yaml
+    dest: .pre-commit-config.yaml
+SciTools/tephi:
+  - source: templates/.pre-commit-config.yaml
+    dest: .pre-commit-config.yaml
+SciTools/test-iris-imagehash:
+  - source: templates/.pre-commit-config.yaml
+    dest: .pre-commit-config.yaml
+SciTools/workflows:
+  - source: templates/.pre-commit-config.yaml
+    dest: .pre-commit-config.yaml

--- a/.github/template-sync.yml
+++ b/.github/template-sync.yml
@@ -7,6 +7,9 @@ SciTools/cf-units:
 SciTools/iris:
   - source: templates/.pre-commit-config.yaml
     dest: .pre-commit-config.yaml
+SciTools/iris-grib:
+  - source: templates/.pre-commit-config.yaml
+    dest: .pre-commit-config.yaml
 SciTools/mo_pack:
   - source: templates/.pre-commit-config.yaml
     dest: .pre-commit-config.yaml

--- a/.github/template-sync.yml
+++ b/.github/template-sync.yml
@@ -2,5 +2,5 @@
 #  included in the templating.
 
 SciTools/iris@demo_20230817_main:
-  - source: templates/.pre-commit-config.yamll
-    dest: .pre-commit-config.yamll
+  - source: templates/.pre-commit-config.yaml
+    dest: .pre-commit-config.yaml

--- a/.github/template-sync.yml
+++ b/.github/template-sync.yml
@@ -1,6 +1,27 @@
 # Note: SciTools/cartopy is managed by a separate development team so is not
 #  included in the templating.
 
-SciTools/iris@demo_20230817_main:
+SciTools/cf-units:
+  - source: templates/.pre-commit-config.yaml
+    dest: .pre-commit-config.yaml
+SciTools/iris:
+  - source: templates/.pre-commit-config.yaml
+    dest: .pre-commit-config.yaml
+SciTools/mo_pack:
+  - source: templates/.pre-commit-config.yaml
+    dest: .pre-commit-config.yaml
+SciTools/nc-time-axis:
+  - source: templates/.pre-commit-config.yaml
+    dest: .pre-commit-config.yaml
+SciTools/python-stratify:
+  - source: templates/.pre-commit-config.yaml
+    dest: .pre-commit-config.yaml
+SciTools/tephi:
+  - source: templates/.pre-commit-config.yaml
+    dest: .pre-commit-config.yaml
+SciTools/test-iris-imagehash:
+  - source: templates/.pre-commit-config.yaml
+    dest: .pre-commit-config.yaml
+SciTools/workflows:
   - source: templates/.pre-commit-config.yaml
     dest: .pre-commit-config.yaml

--- a/.github/template-sync.yml
+++ b/.github/template-sync.yml
@@ -1,6 +1,6 @@
 # Note: SciTools/cartopy is managed by a separate development team so is not
 #  included in the templating.
 
-SciTools/iris@demo_20230817_main:
+trexfeathers/iris@demo_20230817_main:
   - source: templates/.pre-commit-config.yaml
     dest: .pre-commit-config.yaml

--- a/.github/template-sync.yml
+++ b/.github/template-sync.yml
@@ -1,27 +1,6 @@
 # Note: SciTools/cartopy is managed by a separate development team so is not
 #  included in the templating.
 
-SciTools/cf-units:
-  - source: templates/.pre-commit-config.yaml
-    dest: .pre-commit-config.yaml
-SciTools/iris:
-  - source: templates/.pre-commit-config.yaml
-    dest: .pre-commit-config.yaml
-SciTools/mo_pack:
-  - source: templates/.pre-commit-config.yaml
-    dest: .pre-commit-config.yaml
-SciTools/nc-time-axis:
-  - source: templates/.pre-commit-config.yaml
-    dest: .pre-commit-config.yaml
-SciTools/python-stratify:
-  - source: templates/.pre-commit-config.yaml
-    dest: .pre-commit-config.yaml
-SciTools/tephi:
-  - source: templates/.pre-commit-config.yaml
-    dest: .pre-commit-config.yaml
-SciTools/test-iris-imagehash:
-  - source: templates/.pre-commit-config.yaml
-    dest: .pre-commit-config.yaml
-SciTools/workflows:
+SciTools/iris@demo_20230817_main:
   - source: templates/.pre-commit-config.yaml
     dest: .pre-commit-config.yaml

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -13,12 +13,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: BetaHuhn/repo-file-sync-action@3023dac7ce66c18b119e2012348437eadeaea116
+      - uses: Skyvern-AI/repo-file-sync-action@07a31547d9400a3fdbb08fc8ae92243913bdfea5
         with:
           GH_PAT: ${{ secrets.DEMO_SYNC }}
           CONFIG_PATH: .github/workflows/template-sync.yml
           PR_LABELS: |
             Bot
             Type: Infrastructure
-          COMMIT_PREFIX: 👁 Template deviations
+          PR_TITLE: 👁 Template deviations
           PR_BODY: https://github.com/SciTools/.github/tree/main/templates

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -20,5 +20,5 @@ jobs:
           PR_LABELS: |
             Bot
             Type: Infrastructure
-          COMMIT_PREFIX: 👁 Template deviations
-          PR_BODY: "https://github.com/SciTools/.github/tree/main/templates"
+          COMMIT_PREFIX: "👁 TEMPLATE DEVIATIONS:"
+          PR_BODY: "## Please read: https://github.com/SciTools/.github/tree/main/templates"

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -21,4 +21,4 @@ jobs:
             Bot
             Type: Infrastructure
           COMMIT_PREFIX: "👁 TEMPLATE DEVIATIONS:"
-          PR_BODY: "## Please read: https://github.com/trexfeathers/SciTools.github/tree/sync-action/templates"
+          PR_BODY: "## Please read: https://github.com/SciTools/.github/tree/main/templates"

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: rasa/repo-file-sync-action@011c52e270cef47e3ed9af0a7a661d202acb1c72
+      - uses: BetaHuhn/repo-file-sync-action@3023dac7ce66c18b119e2012348437eadeaea116
         with:
           GH_PAT: ${{ secrets.DEMO_SYNC }}
           CONFIG_PATH: .github/workflows/template-sync.yml

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -4,18 +4,24 @@ on:
     # "At 02:00 on day-of-month 1 in every 2nd month."
     - cron: '0 2 1 */2 *'
   workflow_dispatch:
-  push:
 
 jobs:
   sync:
+    if: "github.repository_owner == 'SciTools' || github.event_name == 'workflow_dispatch'"
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
 
+      - id: generate-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.AUTH_APP_ID }}
+          private_key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
+
       - uses: BetaHuhn/repo-file-sync-action@3023dac7ce66c18b119e2012348437eadeaea116
         with:
-          GH_PAT: ${{ secrets.DEMO_SYNC }}
+          GH_INSTALLATION_TOKEN: ${{ steps.generate-token.outputs.token }}
           CONFIG_PATH: .github/template-sync.yml
           PR_LABELS: |
             Bot

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: BetaHuhn/repo-file-sync-action@3023dac7ce66c18b119e2012348437eadeaea116
         with:
           GH_PAT: ${{ secrets.DEMO_SYNC }}
-          CONFIG_PATH: .github/workflows/template-sync.yml
+          CONFIG_PATH: .github/template-sync.yml
           PR_LABELS: |
             Bot
             Type: Infrastructure

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -4,24 +4,18 @@ on:
     # "At 02:00 on day-of-month 1 in every 2nd month."
     - cron: '0 2 1 */2 *'
   workflow_dispatch:
+  push:
 
 jobs:
   sync:
-    if: "github.repository_owner == 'SciTools' || github.event_name == 'workflow_dispatch'"
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
 
-      - id: generate-token
-        uses: tibdex/github-app-token@v2
-        with:
-          app_id: ${{ secrets.AUTH_APP_ID }}
-          private_key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
-
       - uses: BetaHuhn/repo-file-sync-action@3023dac7ce66c18b119e2012348437eadeaea116
         with:
-          GH_INSTALLATION_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_PAT: ${{ secrets.DEMO_SYNC }}
           CONFIG_PATH: .github/workflows/template-sync.yml
           PR_LABELS: |
             Bot

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -21,4 +21,4 @@ jobs:
             Bot
             Type: Infrastructure
           COMMIT_PREFIX: 👁 Template deviations
-          PR_BODY: https://github.com/SciTools/.github/tree/main/templates
+          PR_BODY: "https://github.com/SciTools/.github/tree/main/templates"

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -13,12 +13,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: Skyvern-AI/repo-file-sync-action@07a31547d9400a3fdbb08fc8ae92243913bdfea5
+      - uses: BetaHuhn/repo-file-sync-action@3023dac7ce66c18b119e2012348437eadeaea116
         with:
           GH_PAT: ${{ secrets.DEMO_SYNC }}
           CONFIG_PATH: .github/workflows/template-sync.yml
           PR_LABELS: |
             Bot
             Type: Infrastructure
-          PR_TITLE: 👁 Template deviations
+          COMMIT_PREFIX: 👁 Template deviations
           PR_BODY: https://github.com/SciTools/.github/tree/main/templates

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -1,0 +1,30 @@
+name: Sync template files across repos
+on:
+  schedule:
+    # "At 02:00 on day-of-month 1 in every 2nd month."
+    - cron: '0 2 1 */2 *'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    if: "github.repository_owner == 'SciTools' || github.event_name == 'workflow_dispatch'"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: generate-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.AUTH_APP_ID }}
+          private_key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
+
+      - uses: BetaHuhn/repo-file-sync-action@3023dac7ce66c18b119e2012348437eadeaea116
+        with:
+          GH_INSTALLATION_TOKEN: ${{ steps.generate-token.outputs.token }}
+          CONFIG_PATH: .github/workflows/template-sync.yml
+          PR_LABELS: |
+            Bot
+            Type: Infrastructure
+          COMMIT_PREFIX: 👁 Template deviations
+          PR_BODY: https://github.com/SciTools/.github/tree/main/templates

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -21,4 +21,4 @@ jobs:
             Bot
             Type: Infrastructure
           COMMIT_PREFIX: "👁 TEMPLATE DEVIATIONS:"
-          PR_BODY: "## Please read: https://github.com/SciTools/.github/tree/main/templates"
+          PR_BODY: "## Please read: https://github.com/trexfeathers/SciTools.github/tree/sync-action/templates"

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: BetaHuhn/repo-file-sync-action@3023dac7ce66c18b119e2012348437eadeaea116
+      - uses: rasa/repo-file-sync-action@011c52e270cef47e3ed9af0a7a661d202acb1c72
         with:
           GH_PAT: ${{ secrets.DEMO_SYNC }}
           CONFIG_PATH: .github/workflows/template-sync.yml

--- a/templates/.pre-commit-config.yaml
+++ b/templates/.pre-commit-config.yaml
@@ -1,0 +1,68 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+
+files: |
+    (?x)(
+        noxfile\.py|
+        setup\.py|
+        docs\/.+\.py|
+        benchmarks\/.+\.py|
+    )
+minimum_pre_commit_version: 1.21.0
+
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+        # Prevent giant files from being committed.
+    -   id: check-added-large-files
+        # Check whether files parse as valid Python.
+    -   id: check-ast
+        # Check for file name conflicts on case-insensitive filesytems.
+    -   id: check-case-conflict
+        # Check for files that contain merge conflict strings.
+    -   id: check-merge-conflict
+        # Check for debugger imports and py37+ `breakpoint()` calls in Python source.
+    -   id: debug-statements
+        # Don't commit to main branch.
+    -   id: no-commit-to-branch
+
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.3.4"
+    hooks:
+    -   id: ruff
+        types: [file, python]
+        args: [--fix, --show-fixes]
+    -   id: ruff-format
+        types: [file, python]
+
+-   repo: https://github.com/codespell-project/codespell
+    rev: "v2.2.6"
+    hooks:
+    -   id: codespell
+        types_or: [asciidoc, python, markdown, rst]
+        additional_dependencies: [tomli]
+
+-   repo: https://github.com/PyCQA/flake8
+    rev: 7.0.0
+    hooks:
+    -   id: flake8
+        types: [file, python]
+
+-   repo: https://github.com/asottile/blacken-docs
+    rev: 1.16.0
+    hooks:
+    -   id: blacken-docs
+        types: [file, rst]
+
+-   repo: https://github.com/aio-libs/sort-all
+    rev: v1.2.0
+    hooks:
+    -   id: sort-all
+        types: [file, python]
+
+-   repo: https://github.com/numpy/numpydoc
+    rev: v1.7.0
+    hooks:
+      - id: numpydoc-validation
+        types: [file, python]

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,19 @@
+These files are templates defining the standard format across all SciTools
+repos. Repo deviations from template are periodically identified in pull
+requests by the repo-file-sync-action.
+
+### Possible actions on a deviation pull request
+
+- ✔️ **Merge** - all deviations are re-aligned with the template
+  (E.g. the repo is simply out of date and needs updating).
+- ❌ **Close** - all deviations are kept
+  (E.g. all deviations are required repo-specific detail).
+- ️️✏️ **Edit** - re-align some deviations, keep others.
+- 🏃 **Close then action independently**
+  (E.g. the repo contains content that should be added to the template).
+
+### Further reading
+
+- https://github.com/marketplace/actions/repo-file-sync-action
+- [../.github/workflows/template-sync.yml](../.github/workflows/template-sync.yml)
+- [../.github/template-sync.yml](../.github/template-sync.yml)


### PR DESCRIPTION
You can see a demo of this working here: https://github.com/trexfeathers/iris/pull/88 (I tweaked certain config to temporarily make this work locally).

Don't bother looking at the commit sequence - lots of trial and error. Just look at the diff 😅

Further explanation:

https://github.com/SciTools/.github/blob/33d12ba1aae6bfc7ba72e1830a98de2faff24917/templates/README.md?plain=1#L1-L19