### PR TITLE
Script to make PR authors aware if they are modifying templated files

### DIFF
--- a/templates/_templating_scripting.py
+++ b/templates/_templating_scripting.py
@@ -120,6 +120,8 @@ def notify_updates() -> None:
                         labels_start = gh_command.index("--label")
                         gh_command = gh_command[:labels_start]
                         run(gh_command, check=True)
+                    else:
+                        raise
 
 
 def prompt_share() -> None:

--- a/templates/_templating_scripting.py
+++ b/templates/_templating_scripting.py
@@ -136,7 +136,7 @@ def prompt_share(args: argparse.Namespace) -> None:
     pr_number = args.pr_number
 
     def split_github_url(url: str) -> tuple[str, str, str]:
-        _, org, repo, _, _, ref = urlparse(url).path.split("/")
+        _, org, repo, _, ref = urlparse(url).path.split("/")
         return org, repo, ref
 
     def url_to_short_ref(url: str) -> str:

--- a/templates/_templating_scripting.py
+++ b/templates/_templating_scripting.py
@@ -174,7 +174,7 @@ def prompt_share(args: argparse.Namespace) -> None:
                 "url",
             )["url"]
         short_ref = url_to_short_ref(issue_url)
-        review_body = f"Please action {short_ref}"
+        review_body = f"Please see {short_ref}"
         gh_command = shlex.split(
             f'gh pr review {pr_number} --request-changes --body "{review_body}"'
         )

--- a/templates/_templating_scripting.py
+++ b/templates/_templating_scripting.py
@@ -163,16 +163,14 @@ def prompt_share(args: argparse.Namespace) -> None:
         with NamedTemporaryFile("w") as file_write:
             file_write.write(body)
             file_write.flush()
-            issue_url = gh_json(
-                (
-                    "issue create "
-                    f'--title "{title}" '
-                    f"--body-file {file_write.name} "
-                    "--repo SciTools/.github "
-                    f"--assignee {author}"
-                ),
-                "url",
-            )["url"]
+            gh_command = shlex.split(
+                "gh issue create "
+                f'--title "{title}" '
+                f"--body-file {file_write.name} "
+                "--repo SciTools/.github "
+                f"--assignee {author}"
+            )
+            issue_url = check_output(gh_command).decode("utf-8").strip()
         short_ref = url_to_short_ref(issue_url)
         review_body = f"Please see {short_ref}"
         gh_command = shlex.split(

--- a/templates/_templating_scripting.py
+++ b/templates/_templating_scripting.py
@@ -166,7 +166,7 @@ def prompt_share(args: argparse.Namespace) -> None:
             issue_url = gh_json(
                 (
                     "issue create "
-                    f"--title {title} "
+                    f'--title "{title}" '
                     f"--body-file {file_write.name} "
                     "--repo SciTools/.github "
                     f"--assignee {author}"

--- a/templates/_templating_scripting.py
+++ b/templates/_templating_scripting.py
@@ -62,11 +62,14 @@ class Config:
 CONFIG = Config()
 
 
-def notify_updates() -> None:
+def notify_updates(args: argparse.Namespace) -> None:
     """Create issues on repos that use templates that have been updated.
 
     This function is intended for running on the .github repo.
     """
+    # Always passed (by common code), but never used in this routine.
+    _ = args
+
     def git_diff(*args: str) -> str:
         command = "diff HEAD^ HEAD " + " ".join(args)
         return git_command(command)

--- a/templates/_templating_scripting.py
+++ b/templates/_templating_scripting.py
@@ -155,7 +155,8 @@ def prompt_share() -> None:
                 "gh issue create "
                 f'--title "{title}" '
                 f"--body-file {file_write.name} "
-                "--repo SciTools/.github"
+                "--repo SciTools/.github "
+                f"--assignee {author}"
             )
             run(gh_command, check=True)
 

--- a/templates/_templating_scripting.py
+++ b/templates/_templating_scripting.py
@@ -85,7 +85,7 @@ def notify_updates(args: argparse.Namespace) -> None:
         templatees = CONFIG.templates[template]
 
         diff = git_diff("--", str(template))
-        issue_title = f"The Template for `{template.name}` has been updated"
+        issue_title = f"The template for `{template.name}` has been updated"
         template_relative = template.relative_to(TEMPLATE_REPO_ROOT)
         template_url = (
             f"{SCITOOLS_URL}/.github/blob/main/{template_relative}"
@@ -264,7 +264,7 @@ def main() -> None:
     prompt.add_argument(
         "pr_number",
         type=int,
-        help="The number of the PR to prompt the author of."
+        help="The number of the PR with content that might deserve templating."
     )
     prompt.set_defaults(func=prompt_share)
 


### PR DESCRIPTION
This has a few different permutations, plus I've made some minor changes to the existing `notify_updates()` script, so I intend to produce some demonstrations of this all working before I take it out of draft.

**The demonstrations below use the `demo_templating` branch. The only differences from `prompt-share` are those that enable demonstrations ([see diff](https://github.com/trexfeathers/SciTools.github/compare/prompt-share...trexfeathers:SciTools.github:demo_templating)).**

# `notify_updates()`

The following issues were generated when the workflow ran against the same code used by this branch:

- https://github.com/trexfeathers/iris/issues/91
- https://github.com/trexfeathers/cf-units/issues/7

Thus demonstrating that this PR does not break existing functionality

# `prompt_share()`

The new routine

## Two demo pull requests

- https://github.com/trexfeathers/cf-units/pull/8
- https://github.com/trexfeathers/iris/pull/92

## What these demonstrate

- The form of prompts
  - A new issue on the .github repo
  - A new review on the PR
- Prompting the user when they have modified a templated file
- Prompting the user when their file is a likely candidate for templating (based on a hard coded list of parent directories)
- The ability to ignore un-templated files
- Handling multiple files per commit/PR
- That the list of templated files can differ between repos (Iris versus Cf-units)
- Prompts are only created once per file per pull request

# Proposal for actions on each repo

See these diffs, which introduce an identical new workflow on cf-units and iris (plus temporarily deleting the other workflows!)

- [Cf-units](https://github.com/SciTools/cf-units/compare/main...trexfeathers:cf-units:demo_templating)
- [Iris](https://github.com/SciTools/iris/compare/main...trexfeathers:iris:demo_templating)