### PR TITLE
Templating fixes after SciTools/.github#46 .

### DIFF
--- a/templates/_templating_scripting.py
+++ b/templates/_templating_scripting.py
@@ -69,19 +69,20 @@ def notify_updates() -> None:
             f"{scitools_url}/.github/blob/main/{template_relative}"
         )
         template_link = f"[`{template_relative}`]({template_url})"
-        issue_body = (
-            "The template for {file_link} has been updated.\n\n"
-            "Consider adopting these changes into the repo; "
-            "the changes can be found below.\n\n"
-            f"The template file can be found in the **.github** repo: {template_link}\n\n"
-            "The diff between the specified file is as follows:\n\n"
-            f"```diff\n{diff}\n```"
-        )
         for repo, path_in_repo in templatees:
             file_url = f"{scitools_url}/{repo}/blob/main/{path_in_repo}"
             file_link = f"[`{path_in_repo}`]({file_url})"
+            issue_body = (
+                f"The template for {file_link} has been updated.\n\n"
+                "Consider adopting these changes into the repo; "
+                "the changes can be found below.\n\n"
+                "The template file can be found in the **.github** repo: "
+                f"{template_link}\n\n"
+                "The diff between the specified file is as follows:\n\n"
+                f"```diff\n{diff}\n```"
+            )
             with NamedTemporaryFile("w") as file_write:
-                file_write.write(issue_body.format(file_link=file_link))
+                file_write.write(issue_body)
                 file_write.flush()
                 gh_command = shlex.split(
                     "gh issue create "

--- a/templates/_templating_scripting.py
+++ b/templates/_templating_scripting.py
@@ -63,7 +63,10 @@ def notify_updates() -> None:
         templatees = CONFIG.templates[template]
 
         diff = git_diff("--", str(template))
-        issue_title = f"The Template for `{template.name}` has been updated"
+        issue_title = (
+            f"The Template for `{template.relative_to(TEMPLATES_DIR)}` "
+            "has been updated"
+        )
         template_relative = template.relative_to(GIT_ROOT)
         template_url = (
             f"{scitools_url}/.github/blob/main/{template_relative}"


### PR DESCRIPTION
The [action](https://github.com/SciTools/.github/actions/runs/13973795516) running after #46 highlighted two problems:

- The name in the issue titles is not specific enough
  - E.g. the following referred to a README in a subdirectory: SciTools/iris#6373
- Use of `string.format()` on a string that could contain arbitrary Python code introduced a 'format string vulnerability'. Not a security vulnerability, but it did cause an inadvertent crash because the code included curly braces.

This PR fixes the above problems.