### PR TITLE
Include workflows and test-iris-imagehash in config file

### DIFF
--- a/templates/_templating_config.json
+++ b/templates/_templating_config.json
@@ -8,7 +8,9 @@
     "iris-grib": ".pre-commit-config.yaml",
     "nc-time-axis": ".pre-commit-config.yaml",
     "python-stratify": ".pre-commit-config.yaml",
-    "tephi": ".pre-commit-config.yaml"
+    "tephi": ".pre-commit-config.yaml",
+    "workflows": ".pre-commit-config.yaml",
+    "test-iris-imagehash": ".pre-commit-config.yaml"
   },
   "benchmarks/custom_bms/install.py": {
     "iris": "benchmarks/custom_bms/install.py",


### PR DESCRIPTION
Prompted by https://github.com/SciTools/.github/issues/42#issuecomment-2740890838.

Files located at [test-iris-imagehash/.pre-commit-config.yaml](https://github.com/SciTools/test-iris-imagehash/blob/1b29a0e71357792ee5da609d6bc98b682cf53487/.pre-commit-config.yaml) and [workflows/.pre-commit-config.yaml](https://github.com/SciTools/workflows/blob/0a0985242d58ce4131f7361f4812c8c6a36e4ae8/.pre-commit-config.yaml). 