### PR TITLE
RETRY: Give the option to ignore files from templating prompt

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -23,11 +23,6 @@ templates and how they map to files in the SciTools repositories.
 files that are found in commonly templated directories within the SciTools repositories,
 but that we do not wish to template.
 
-- If there is a file that you think should be templated, but can't be done imminently, and
-the constant reminders are hindering your workflow, consider ensuring the task is detailed in 
-the [`checklist`](https://github.com/SciTools/.github/issues/42), and then add it to the exclude
-list.
-
 [`_templating_scripting.py`](_templating_scripting.py) contains the logic for
 communicating template updates around SciTools - using GitHub issues and
 comments. It is called by two GitHub Actions workflows:
@@ -52,6 +47,11 @@ scripts.
 Files DO NOT need to be identical - they are human-readable not 
 machine-readable, so can include whatever placeholders / optional content is
 considered appropriate.
+
+If there is a file that you think should be templated, but can't be done imminently, and
+the constant reminders are hindering your workflow, consider ensuring the task is detailed in 
+the [`checklist`](https://github.com/SciTools/.github/issues/42), and then add it to the exclude
+list.
 
 ## Please contribute!
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -19,6 +19,10 @@ installable package or similar - less overhead and easier to follow.
 [`_templating_include.json`](_templating_include.json) is the 'index' of all the
 templates and how they map to files in the SciTools repositories.
 
+[`_templating_exclude.json`](_templating_exclude.json) is the 'index' of all the
+files that are found in commonly templated directories within the SciTools repositories,
+but that we do not wish to template. 
+
 [`_templating_scripting.py`](_templating_scripting.py) contains the logic for
 communicating template updates around SciTools - using GitHub issues and
 comments. It is called by two GitHub Actions workflows:

--- a/templates/README.md
+++ b/templates/README.md
@@ -21,7 +21,7 @@ templates and how they map to files in the SciTools repositories.
 
 [`_templating_exclude.json`](_templating_exclude.json) is the 'index' of all the
 files that are found in commonly templated directories within the SciTools repositories,
-but that we do not wish to template. 
+but that we do not wish to template.
 
 [`_templating_scripting.py`](_templating_scripting.py) contains the logic for
 communicating template updates around SciTools - using GitHub issues and
@@ -53,3 +53,4 @@ considered appropriate.
 This directory needs to grow. Any files you can think to template will be a 
 valuable addition.
 **Remember to update [`_templating_include.json`](_templating_include.json).**
+

--- a/templates/README.md
+++ b/templates/README.md
@@ -23,6 +23,11 @@ templates and how they map to files in the SciTools repositories.
 files that are found in commonly templated directories within the SciTools repositories,
 but that we do not wish to template.
 
+- If there is a file that you think should be templated, but can't be done imminently, and
+the constant reminders are hindering your workflow, consider ensuring the task is detailed in 
+the [`checklist`](https://github.com/SciTools/.github/issues/42), and then add it to the exclude
+list.
+
 [`_templating_scripting.py`](_templating_scripting.py) contains the logic for
 communicating template updates around SciTools - using GitHub issues and
 comments. It is called by two GitHub Actions workflows:

--- a/templates/README.md
+++ b/templates/README.md
@@ -16,7 +16,7 @@ installable package or similar - less overhead and easier to follow.
 
 ## How it works
 
-[`_templating_config.json`](_templating_config.json) is the 'index' of all the
+[`_templating_include.json`](_templating_include.json) is the 'index' of all the
 templates and how they map to files in the SciTools repositories.
 
 [`_templating_scripting.py`](_templating_scripting.py) contains the logic for
@@ -48,4 +48,4 @@ considered appropriate.
 
 This directory needs to grow. Any files you can think to template will be a 
 valuable addition.
-**Remember to update [`_templating_config.json`](_templating_config.json).**
+**Remember to update [`_templating_include.json`](_templating_include.json).**

--- a/templates/_templating_exclude.json
+++ b/templates/_templating_exclude.json
@@ -1,13 +1,42 @@
 {
-  "iris" : [],
-  "iris-grib" : [],
+  "iris" : [
+    "noxfile.py",
+    "README.md",
+    "docs/src/why_iris.rst"
+  ],
+  "iris-grib" : [
+    "noxfile.py",
+    "README.md"
+  ],
   "tephi" : [
+    "tox.ini",
+    "README.md",
     "index.ipynb"
   ],
-  "python-stratify" : [],
-  "iris-esmf-regrid":  [],
-  "cf-units" : [],
-  "nc-time-axis" : [],
-  "workflows" : [],
-  "test-iris-imagehash" : []
+  "python-stratify" : [
+    "README.md",
+    "Dockerfile",
+    "index.ipynb",
+    "summary.png"
+  ],
+  "iris-esmf-regrid":  [
+    "noxfile.py",
+    "README.md"
+  ],
+  "cf-units" : [
+    "tox.ini",
+    "README.md"
+  ],
+  "nc-time-axis" : [
+    "README.md",
+    "example_plot.png"
+  ],
+  "workflows" : [
+    "README.md",
+    "version.txt"
+  ],
+  "test-iris-imagehash" : [
+    ".cirrus.yml",
+    "README.rst"
+  ]
 }

--- a/templates/_templating_exclude.json
+++ b/templates/_templating_exclude.json
@@ -1,0 +1,13 @@
+{
+  "iris" : [],
+  "iris-grib" : [],
+  "tephi" : [
+    "index.ipynb"
+  ],
+  "python-stratify" : [],
+  "iris-esmf-regrid":  [],
+  "cf-units" : [],
+  "nc-time-axis" : [],
+  "workflows" : [],
+  "test-iris-imagehash" : []
+}

--- a/templates/_templating_include.json
+++ b/templates/_templating_include.json
@@ -1,5 +1,6 @@
 {
-  "_templating_config.json": {},
+  "_templating_include.json": {},
+  "_templating_exclude.json": {},
   "_templating_scripting.py": {},
   "README.md": {},
   ".pre-commit-config.yaml": {


### PR DESCRIPTION
#### This is a copy of https://github.com/SciTools/.github/pull/69, which didn't work. 
(I believe this was due to the fact I edited the file, then renamed it, or something strange like that.)

# Pull Request
This has been tested locally, and the "ignored" switch works as expected.

This creates another config file, and offers a list of files per repo that won't get prompted for templating when adding a new file to the common template directories.