### PR TITLE
Ensured any bot PRs will assign humans to issues

### DIFF
--- a/templates/_templating_scripting.py
+++ b/templates/_templating_scripting.py
@@ -186,6 +186,7 @@ def prompt_share(args: argparse.Namespace) -> None:
             for commit in commits
             for commit_author in get_commit_authors(commit)
         )
+
     human_authors = get_all_authors() - BOT_AUTHORS
     if human_authors == set():
         review_body = (
@@ -206,16 +207,17 @@ def prompt_share(args: argparse.Namespace) -> None:
         return
 
     def create_issue(title: str, body: str) -> None:
+        assignee = author
         # Check that an issue with this title isn't already on the .github repo.
         existing_issues = gh_json(
             "issue list --state all --repo SciTools/.github", "title"
         )
         if any(issue["title"] == title for issue in existing_issues):
             return
-        if author in BOT_AUTHORS:
+        if assignee in BOT_AUTHORS:
             # if the author is a bot, we don't want to assign the issue to the bot,
             # so instead choose a human author from the latest commit
-            author = human_authors[0]
+            assignee = human_authors[0]
 
         with NamedTemporaryFile("w") as file_write:
             file_write.write(body)
@@ -225,7 +227,7 @@ def prompt_share(args: argparse.Namespace) -> None:
                 f'--title "{title}" '
                 f"--body-file {file_write.name} "
                 "--repo SciTools/.github "
-                f"--assignee {author}"
+                f"--assignee {assignee}"
             )
             issue_url = check_output(gh_command).decode("utf-8").strip()
         short_ref = url_to_short_ref(issue_url)

--- a/templates/_templating_scripting.py
+++ b/templates/_templating_scripting.py
@@ -153,7 +153,7 @@ def prompt_share(args: argparse.Namespace) -> None:
         command = shlex.split(f"gh {sub_command} --json {field}")
         return json.loads(check_output(command))
 
-    pr_number = "https://github.com/SciTools/cf-units/pull/571"
+    pr_number = args.pr_number
 
     def split_github_url(url: str) -> tuple[str, str, str]:
         _, org, repo, _, ref = urlparse(url).path.split("/")

--- a/templates/_templating_scripting.py
+++ b/templates/_templating_scripting.py
@@ -14,7 +14,7 @@ from urllib.parse import urlparse
 SCITOOLS_URL = "https://github.com/SciTools"
 TEMPLATES_DIR = Path(__file__).parent.resolve()
 TEMPLATE_REPO_ROOT = TEMPLATES_DIR.parent
-# ensure any new bots have both a "app/" prefix and a "[bot]" prefix version
+# ensure any new bots have both a "app/" prefix and a "[bot]" postfix version
 BOTS = ["dependabot[bot]", "app/dependabot", "pre-commit-ci[bot]", "app/pre-commit-ci"]
 
 

--- a/templates/_templating_scripting.py
+++ b/templates/_templating_scripting.py
@@ -14,9 +14,8 @@ from urllib.parse import urlparse
 SCITOOLS_URL = "https://github.com/SciTools"
 TEMPLATES_DIR = Path(__file__).parent.resolve()
 TEMPLATE_REPO_ROOT = TEMPLATES_DIR.parent
-# bots are named differently depending on their relationship to the PR
-# just put the base name here, the rest is calculated later
-BOTS = ["dependabot", "pre-commit-ci"]
+# ensure any new bots have both a "app/" prefix and a "[bot]" prefix version
+BOTS = ["dependabot[bot]", "app/dependabot", "pre-commit-ci[bot]", "app/pre-commit-ci"]
 
 
 def git_command(command: str) -> str:
@@ -189,7 +188,7 @@ def prompt_share(args: argparse.Namespace) -> None:
             for commit_author in get_commit_authors(commit)
         )
 
-    human_authors = get_all_authors() - set(["app/" + bot for bot in BOTS]) - set([bot + "[bot]" for bot in BOTS])
+    human_authors = get_all_authors() - set(BOTS)
     if human_authors == set():
         review_body = (
             f"### [Templating]({SCITOOLS_URL}/.github/blob/main/templates)\n\n"
@@ -217,7 +216,7 @@ def prompt_share(args: argparse.Namespace) -> None:
         )
         if any(issue["title"] == title for issue in existing_issues):
             return
-        if assignee in (bot + "[bot]" for bot in BOTS) or assignee in ("app/" + bot for bot in BOTS):
+        if assignee in BOTS:
             # if the author is a bot, we don't want to assign the issue to the bot
             assignee = list(human_authors)[0]
 


### PR DESCRIPTION
See https://github.com/SciTools/cf-units/pull/571 for evidence it works. 

I couldn't create an issue to test https://github.com/SciTools/.github/pull/78/commits/69dadacab8da5de84440e06df9fc8531d8f649c7, due to the nature of the code, but I beleive the functionality is the same.