### PR TITLE
Templating: add the `SPRING_CLEANING` flag

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -30,9 +30,15 @@ comments. It is called by two GitHub Actions workflows:
 - [`template-update-notification.yml`](../.github/workflows/template-update-notification.yml)
 uses the `notify_updates()` function to raise issues on all relevant
 repositories when a template is updated, or a new one created.
+
 - [SciTools/workflows `ci-template-check.yml`](https://github.com/SciTools/workflows/blob/main/.github/workflows/ci-template-check.yml)
 uses the `prompt_share()` function to remind repository developers if they are
 modifying a templated file and should consider sharing the change.
+
+- `SPRING_CLEANING` flag in [`_templating_scripting.py`](_templating_scripting.py):
+a mechanism for disabling the issues and comments if the dev team is
+deliberately doing intense work on templates and templated files (the volume
+of un-actioned notifications would be overwhelming).
 
 All other files in this directory are the templates themselves.
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -30,12 +30,11 @@ comments. It is called by two GitHub Actions workflows:
 - [`template-update-notification.yml`](../.github/workflows/template-update-notification.yml)
 uses the `notify_updates()` function to raise issues on all relevant
 repositories when a template is updated, or a new one created.
-
 - [SciTools/workflows `ci-template-check.yml`](https://github.com/SciTools/workflows/blob/main/.github/workflows/ci-template-check.yml)
 uses the `prompt_share()` function to remind repository developers if they are
 modifying a templated file and should consider sharing the change.
 
-- `SPRING_CLEANING` flag in [`_templating_scripting.py`](_templating_scripting.py):
+`SPRING_CLEANING` flag in [`_templating_scripting.py`](_templating_scripting.py):
 a mechanism for disabling the issues and comments if the dev team is
 deliberately doing intense work on templates and templated files (the volume
 of un-actioned notifications would be overwhelming).

--- a/templates/_templating_scripting.py
+++ b/templates/_templating_scripting.py
@@ -10,6 +10,10 @@ from tempfile import NamedTemporaryFile
 from typing import NamedTuple
 from urllib.parse import urlparse
 
+# A mechanism for disabling the issues and comments if the dev team is
+#  deliberately doing intense work on templates and templated files (the volume
+#  of un-actioned notifications would be overwhelming).
+SPRING_CLEANING = True
 
 SCITOOLS_URL = "https://github.com/SciTools"
 TEMPLATES_DIR = Path(__file__).parent.resolve()
@@ -71,6 +75,12 @@ def notify_updates(args: argparse.Namespace) -> None:
     """
     # Always passed (by common code), but never used in this routine.
     _ = args
+
+    if SPRING_CLEANING:
+        print(
+            "Spring cleaning is in effect; no issues/comments will be posted."
+        )
+        return
 
     def git_diff(*args: str) -> str:
         command = "diff HEAD^ HEAD " + " ".join(args)
@@ -149,6 +159,12 @@ def prompt_share(args: argparse.Namespace) -> None:
 
     This function is intended for running on a PR on a 'target repo'.
     """
+    if SPRING_CLEANING:
+        print(
+            "Spring cleaning is in effect; no issues/comments will be posted."
+        )
+        return
+
     def gh_json(sub_command: str, field: str) -> dict:
         command = shlex.split(f"gh {sub_command} --json {field}")
         return json.loads(check_output(command))


### PR DESCRIPTION
For disabling the issues and comments from being posted. Useful when we know we'll be making lots of changes quickly.