### PR TITLE
Improve the readability of template share prompts

### DIFF
--- a/templates/_templating_scripting.py
+++ b/templates/_templating_scripting.py
@@ -232,8 +232,8 @@ def prompt_share(args: argparse.Namespace) -> None:
         existing_issues = gh_json(
             "issue list --state all --repo SciTools/.github", "title"
         )
-        # if any(issue["title"] == title for issue in existing_issues):
-        #     return
+        if any(issue["title"] == title for issue in existing_issues):
+            return
 
         if assignee in BOTS:
             # if the author is a bot, we don't want to assign the issue to the bot


### PR DESCRIPTION
Any frustration with templating will risk turning people off the concept. I think one of the big remaining frustrations is when a pull request gets hit by a blizzard of linked issues, so I am proposing condensing everything into a single issue.

Demonstration: https://github.com/SciTools/.github/pull/154#issuecomment-2956158729