### PR TITLE
Update `MANIFEST.in` template in light of cf-units and tephi improvements

### DIFF
--- a/templates/MANIFEST.in
+++ b/templates/MANIFEST.in
@@ -26,17 +26,6 @@ recursive-include src *.py
 
 
 #---------
-# SECTION: docs
-prune docs
-# and if required ... include ONLY docs source files.
-# E.G. recursive-include docs *.rst *.inc
-    # principles:
-    #    - use prune to ignore everything (optionally: except the docs sources)
-    # hints:
-    #    - most projects don't want to package the docs, but some currently do (cf-units).
-
-
-#---------
 # SECTION: requirements
 prune requirements
 recursive-include requirements *.txt
@@ -87,6 +76,7 @@ prune .github
 prune .nox
 prune .tox
 prune .coverage
+prune docs
 # (2) top-level files to omit
 exclude .coveragerc
 # (3) file types (path patterns) to skip everywhere

--- a/templates/MANIFEST.in
+++ b/templates/MANIFEST.in
@@ -34,7 +34,6 @@ recursive-include requirements *.txt
     # hints:
     #    - not all projects include requirements, but they can be drawn in anyway by dynamic dependencies
     #        in the setuptools build process, linked via config in pyproject.toml
-    #    - for some repos, the *.txt are actually lockfiles.  This probably needs fixing.
 
 
 #---------


### PR DESCRIPTION
- Exclude docs directory for ALL repos - we have confirmed that this was a legacy hangover from cf-units and tephi
- Remove the note about some lock files being `.txt` - have the opportunity to fix that in cf-units 
  (SciTools/cf-units#608)