### PR TITLE
Update manifest references

### DIFF
--- a/templates/_templating_include.json
+++ b/templates/_templating_include.json
@@ -11,9 +11,7 @@
     "mo_pack": "MANIFEST.in",
     "nc-time-axis": "MANIFEST.in",
     "python-stratify": "MANIFEST.in",
-    "tephi": "MANIFEST.in",
-    "workflows": "MANIFEST.in",
-    "test-iris-imagehash": "MANIFEST.in"
+    "tephi": "MANIFEST.in"
   },
   ".pre-commit-config.yaml": {
     "cf-units": ".pre-commit-config.yaml",


### PR DESCRIPTION
    I have removed the following 2 entries as they do not require a MANIFEST.in file.
    
    "workflows": "MANIFEST.in"
    "test-iris-imagehash": "MANIFEST.in"