### PR TITLE
Pre-commit: use ruff-check instead of ruff

### DIFF
--- a/templates/.pre-commit-config.yaml
+++ b/templates/.pre-commit-config.yaml
@@ -90,7 +90,7 @@ repos:
     # This template does not keep up-to-date with versions, visit the repo to see the most recent release.
     rev: "v0.7.4"
     hooks:
-    -   id: ruff
+    -   id: ruff-check
         types: [file, python]
         args: [--fix, --show-fixes]
     -   id: ruff-format


### PR DESCRIPTION
Closes #209

@scitools-templating: please no update notification on: iris-grib