### PR TITLE
Peloton update: further paginate the Discussions query

### DIFF
--- a/peloton/update_project.py
+++ b/peloton/update_project.py
@@ -694,6 +694,7 @@ class DiscussionsQuery(IssuesQuery):
     Discussions share a lot of properties with Issues, so we can reuse
     much of the parent class.
     """
+    _PAGINATION = 25
     _selector_kwargs = IssuesQuery._selector_kwargs | dict(type="DISCUSSION")
     _item_types = (github_schema.Discussion,)
 


### PR DESCRIPTION
Apparently we have recently reached a critical mass of Discussion data which goes beyond some limit in GitHub:

```
Resource limits for this query exceeded
```

So this PR just reduces the pagination, specifically for discussions. Is working locally for me.

How to try for yourself: https://github.com/SciTools/.github/blob/main/peloton/README.md