### PR TITLE
Corrections for pyproject.toml in _templating_include.json

### DIFF
--- a/templates/_templating_include.json
+++ b/templates/_templating_include.json
@@ -131,10 +131,8 @@
     "python-stratify": "pyproject.toml",
     "tephi": "pyproject.toml",
     "cf-units": "pyproject.toml",
-    "workflows": "pyproject.toml",
     "mo_pack": "pyproject.toml",
     "test-iris-imagehash": "pyproject.toml",
-    "iris-sample-data": "pyproject.toml",
-    "iris-abfs": "pyproject.toml"
+    "iris-abf": "pyproject.toml"
   }
 }


### PR DESCRIPTION
Two repos had typos, two were included despite not having a `pyproject.toml` file.