### PR TITLE
Align with latest repo-review advice from `2025.11.21`

### DIFF
--- a/templates/.pre-commit-config.yaml
+++ b/templates/.pre-commit-config.yaml
@@ -5,7 +5,9 @@
 
 ci:
   autofix_prs: false
+  autofix_commit_msg: "style: pre-commit fixes"
   autoupdate_commit_msg: "chore: update pre-commit hooks"
+  autoupdate_schedule: "monthly"
 
 
 # Alphabetised, for lack of a better order.

--- a/templates/pyproject.toml
+++ b/templates/pyproject.toml
@@ -127,6 +127,7 @@ exclude = [
 [tool.pytest.ini_options] # The list of keys vary by repository
 addopts = ["-ra", "-v", "--strict-config", "--strict-markers", "--doctest-modules"] # This addopts list varies by repository
 testpaths = "<PATH_TO_MAIN_CODE>" # e.g "cf_units" or "lib/iris"
+log_level = "INFO"
 
 [tool.repo-review]
 # A list of the currently failing repo-review checks, to be fixed later, different for every repository.


### PR DESCRIPTION
xref: https://github.com/scientific-python/cookie/releases/tag/2025.11.21

Closes #232

@scitools-templating: please no update notification on: iris-grib