### PR TITLE
Don't report html responses for 'normal' redirects

### DIFF
--- a/templates/github/workflows/ci-linkchecks.yml
+++ b/templates/github/workflows/ci-linkchecks.yml
@@ -36,6 +36,7 @@ jobs:
           args: |
             --verbose
             --max-concurrency 1
+            --accept 301,302,307,308
             './docs/**/*.rst'
             './docs/**/*.inc'
             './lib/**/*.py'


### PR DESCRIPTION
Changes ported from https://github.com/SciTools/iris/pull/7148 
Look generally useful