### PR TITLE
Relax glob on .github directory for pre-commit config

### DIFF
--- a/templates/.pre-commit-config.yaml
+++ b/templates/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ ci:
 # Alphabetised, for lack of a better order.
 files: |
     (?x)(
-        .github\/workflows\/.*|
+        .github\/.*|
         benchmarks\/.+\.py|
         docs\/.+\.py|
         lib\/.+\.py|


### PR DESCRIPTION
# Pull Request

Fixes #270 

## Details
Relaxes the `.github` glob in the `files` entry of `pre-commit-config.yaml` to include the whole `.github` directory, rather than just the `workflows` subdirectory.

This allows files in the root .github directory, such as `dependabot.yml`, to be audited by the pre-commit hooks.
At the moment, tools like **zizmor** are missing some important files due to this glob.