### PR TITLE
Update Peloton repos - include pint-cf, remove pp-mo repos

### DIFF
--- a/peloton/update_project.py
+++ b/peloton/update_project.py
@@ -63,12 +63,12 @@ def build_github_query(
 ):
     base_conditions = (
         "org:SciTools org:SciTools-incubator org:SciTools-classroom "
-        "repo:pp-mo/ncdata repo:pp-mo/ugrid-checks "
+        "repo:pgamez/pint-cf "
     )
     """
     https://github.com/search?q=org%3ASciTools+org%3ASciTools-incubator
     +org%3ASciTools-classroom
-    +repo%3App-mo%2Fncdata+repo%3App-mo%2Fugrid-checks
+    +repo%3Apgamez%2Fpint-cf
     """
 
     if all_accessibility:


### PR DESCRIPTION
We're really excited about [pgamez/pint-cf](https://github.com/pgamez/pint-cf)

The pp-mo repos have now been migrated into the [SciTools](https://github.com/SciTools) organization